### PR TITLE
moving to python-hcl2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ from setuptools import setup
 # I've tried pyproject.toml but console_scripts weren't supported yet
 setup(
     packages=["tf_datadog_docs"],
-    install_requires=["inflection", "pyhcl", "pyyaml"],
+    install_requires=["inflection", "python-hcl2", "pyyaml"],
     entry_points={
         "console_scripts": [
             "tf_datadog_docs=tf_datadog_docs:main",
-            "tf_datadog_docs_index=tf_datadog_docs:add_to_local_index"
+            "tf_datadog_docs_index=tf_datadog_docs:add_to_local_index",
         ],
-    }
+    },
 )


### PR DESCRIPTION
pyhcl supports up to tf 12 and gave a few parse errors. Up until now I've worked around the parse issues but this PR adds `python-hcl2` as a dependency in stead of `pyhcl`. The format is mostly the same but I keep a compatibility layer in between to be able to move back if needed. Wasn't aware of `python-hcl2` before
